### PR TITLE
Change opt char to int for armv7 compatability

### DIFF
--- a/xtitle.c
+++ b/xtitle.c
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
 	visible = false;
 	char *format = NULL;
 	int truncate = 0;
-	char opt;
+	int opt;
 
 	while ((opt = getopt(argc, argv, "hvseif:t:")) != -1) {
 		switch (opt) {


### PR DESCRIPTION
This change solves the same issue for this package that was addressed in https://github.com/baskerville/xdo/issues/6, enabling compatibility with ARMv7 chipsets such as the Raspberry Pi 2&3.